### PR TITLE
fix: resolve settings toggler click issue on TV

### DIFF
--- a/src/components/settings-row.tsx
+++ b/src/components/settings-row.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import { StyleSheet, Text, View, Switch, Pressable } from "react-native";
+import { StyleSheet, Switch, Text, View } from "react-native";
 import { SpatialNavigationFocusableView } from "react-tv-space-navigation";
 import { getThemeColors } from "../constants/theme";
 import {
@@ -50,20 +50,17 @@ export const SettingRow = memo(
     return (
       <SpatialNavigationFocusableView onSelect={onToggle}>
         {({ isFocused }) => (
-          <Pressable
-            style={[styles.row, isFocused && styles.rowFocused]}
-            onPress={onToggle}
-          >
+          <View style={[styles.row, isFocused && styles.rowFocused]}>
             <Text style={styles.label}>{label}</Text>
-            <Switch
-              value={isEnabled}
-              onValueChange={onToggle}
-              trackColor={{ false: "#767577", true: colorPrimary }}
-              thumbColor={isEnabled ? "#fff" : "#f4f3f4"}
-              // Disable standard focus for switch since the parent handles it
-              focusable={false}
-            />
-          </Pressable>
+            <View pointerEvents="none">
+              <Switch
+                value={isEnabled}
+                trackColor={{ false: "#767577", true: colorPrimary }}
+                thumbColor={isEnabled ? "#fff" : "#f4f3f4"}
+                focusable={false}
+              />
+            </View>
+          </View>
         )}
       </SpatialNavigationFocusableView>
     );


### PR DESCRIPTION
## Summary
- Fixed the issue where clicking the background of a settings row didn't always toggle the switch on all TV platforms
- Root cause: three competing event handlers (`SpatialNavigationFocusableView.onSelect`, `Pressable.onPress`, `Switch.onValueChange`) could interfere with each other, especially on TV platforms where touch event propagation differs

## Changes
- `src/components/settings-row.tsx`:
  - Replaced `Pressable` wrapper with plain `View` — eliminates duplicate touch handler
  - Wrapped `Switch` in `<View pointerEvents="none">` — prevents the Switch from intercepting clicks meant for the row
  - Removed `onValueChange` from Switch and `onPress` from the row — `SpatialNavigationFocusableView.onSelect` is now the single source of truth for toggle interaction
  - Removed unused `Pressable` import

## Before / After

**Before:** Three competing handlers could cause missed toggles:
```
SpatialNavigationFocusableView (onSelect) → Pressable (onPress) → Switch (onValueChange)
```

**After:** Single handler, Switch is purely visual:
```
SpatialNavigationFocusableView (onSelect) → View → Switch (display only)
```

## Test plan
- [ ] Navigate to Settings screen on Android TV emulator
- [ ] Focus a source row and press Enter — verify toggle works
- [ ] Click the row background (not the switch) — verify toggle works
- [ ] Click directly on the switch area — verify toggle still works (via parent)
- [ ] Verify at least one source remains enabled (guard logic)
- [ ] Test on tvOS simulator with remote control

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved settings row component for better spatial navigation support. Switch toggling now responds to container selection while maintaining focus-based visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->