### PR TITLE
fix: add vertical gap between reciter cards in home grid

### DIFF
--- a/src/components/section-reciters-grid.tsx
+++ b/src/components/section-reciters-grid.tsx
@@ -46,6 +46,7 @@ export default function SectionRecitersGrid({
             width: itemWidth,
             height: itemHeight,
             marginHorizontal: 4,
+            marginVertical: 8,
           },
         ]}
       >
@@ -78,7 +79,7 @@ export default function SectionRecitersGrid({
         flexDirection: isRTL ? 'row-reverse' : 'row',
       }}
       numberOfColumns={cardsPerRow}
-      itemHeight={itemHeight}
+      itemHeight={itemHeight + 16}
       renderItem={renderItem}
       rowContainerStyle={{}}
     />


### PR DESCRIPTION
## Problem
There was no vertical spacing between reciter cards in the home grid, causing them to appear cramped.

## Fix
- Added `marginVertical: 8` to each card item in `section-reciters-grid.tsx`
- Updated the virtualized grid's `itemHeight` by +16px to prevent row overlap

## Screenshot of Solve Now
<img width="1648" height="1023" alt="image" src="https://github.com/user-attachments/assets/c5ce2bd3-a8fc-4b52-9592-7fb2c4df0ea8" />

Closes #23 